### PR TITLE
Changed log level from .emerg to .err

### DIFF
--- a/examples/log_handler.zig
+++ b/examples/log_handler.zig
@@ -20,6 +20,6 @@ pub fn log(
 pub fn panic(msg: []const u8, trace: ?*std.builtin.StackTrace) noreturn {
     term.deinit();
     //std.debug.print("wtf?", .{});
-    log(.emerg, .examples, "{s}", .{msg});
+    log(.err, .examples, "{s}", .{msg});
     std.builtin.default_panic(msg, trace);
 }


### PR DESCRIPTION
Looks like the newest std library doesn't have a .emerge field in std.log.Level. So I changed it to .err so zbox can still compile examples.

```bash
 $ zig build                                                                         
./examples/log_handler.zig:23:9: error: enum 'std.log.Level' has no field named 'emerg'    
    log(.emerg, .examples, "{s}", .{msg});                                           
        ^                                                                            
/usr/lib/zig/lib/std/log.zig:75:19: note: 'std.log.Level' declared here              
pub const Level = enum { 
```